### PR TITLE
 Fixed selector warnings in `AMTextFieldPickerExtension`

### DIFF
--- a/AMTextFieldPickerExtension.xcodeproj/project.pbxproj
+++ b/AMTextFieldPickerExtension.xcodeproj/project.pbxproj
@@ -7,11 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		159B7BB3A3684770813805A7 /* Pods_AMTextFieldPickerExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1BDC0C50B5BD4B94606F2D2 /* Pods_AMTextFieldPickerExtension.framework */; };
 		924380721B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 924380711B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		924380781B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9243806C1B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.framework */; };
 		9243807F1B3B4A5900DBD4A8 /* AMTextFieldPickerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9243807E1B3B4A5900DBD4A8 /* AMTextFieldPickerExtensionTests.swift */; };
 		9243808B1B3B4A8C00DBD4A8 /* UITextField+AMSetPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9243808A1B3B4A8C00DBD4A8 /* UITextField+AMSetPicker.swift */; };
-		C459106C9582AB5707721CD5 /* Pods_AMTextFieldPickerExtensionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30D019B73A566313ABBBD354 /* Pods_AMTextFieldPickerExtensionTests.framework */; };
+		A167B3F5E28028734F8C73AA /* Pods_AMTextFieldPickerExtensionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAF13567F3F2B77D3465DD1B /* Pods_AMTextFieldPickerExtensionTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,8 +26,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		30D019B73A566313ABBBD354 /* Pods_AMTextFieldPickerExtensionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AMTextFieldPickerExtensionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		64D527938E26F5D4731A14F7 /* Pods-AMTextFieldPickerExtensionTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AMTextFieldPickerExtensionTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests.debug.xcconfig"; sourceTree = "<group>"; };
+		87D7E3BC68669719C0AC3EED /* Pods-AMTextFieldPickerExtensionTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AMTextFieldPickerExtensionTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests.release.xcconfig"; sourceTree = "<group>"; };
+		91E0D953CC9FCB5821FD1CA7 /* Pods-AMTextFieldPickerExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AMTextFieldPickerExtension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AMTextFieldPickerExtension/Pods-AMTextFieldPickerExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		9243806C1B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AMTextFieldPickerExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		924380701B3B4A5900DBD4A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		924380711B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMTextFieldPickerExtension.h; sourceTree = "<group>"; };
@@ -34,7 +35,10 @@
 		9243807D1B3B4A5900DBD4A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9243807E1B3B4A5900DBD4A8 /* AMTextFieldPickerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMTextFieldPickerExtensionTests.swift; sourceTree = "<group>"; };
 		9243808A1B3B4A8C00DBD4A8 /* UITextField+AMSetPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+AMSetPicker.swift"; sourceTree = "<group>"; };
-		E18BE1EEF891C05C1222A4FA /* Pods-AMTextFieldPickerExtensionTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AMTextFieldPickerExtensionTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests.release.xcconfig"; sourceTree = "<group>"; };
+		BDF0A5FB18F1E7F175678E7A /* Pods-AMTextFieldPickerExtensionTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AMTextFieldPickerExtensionTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CAF13567F3F2B77D3465DD1B /* Pods_AMTextFieldPickerExtensionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AMTextFieldPickerExtensionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1BDC0C50B5BD4B94606F2D2 /* Pods_AMTextFieldPickerExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AMTextFieldPickerExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF2D965EFBC89B3F28CA0182 /* Pods-AMTextFieldPickerExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AMTextFieldPickerExtension.release.xcconfig"; path = "Pods/Target Support Files/Pods-AMTextFieldPickerExtension/Pods-AMTextFieldPickerExtension.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,6 +46,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				159B7BB3A3684770813805A7 /* Pods_AMTextFieldPickerExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -50,17 +55,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				924380781B3B4A5900DBD4A8 /* AMTextFieldPickerExtension.framework in Frameworks */,
-				C459106C9582AB5707721CD5 /* Pods_AMTextFieldPickerExtensionTests.framework in Frameworks */,
+				A167B3F5E28028734F8C73AA /* Pods_AMTextFieldPickerExtensionTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		679CE2193D499980177EA65D /* Frameworks */ = {
+		7081A8798E2E4FE7757C2B58 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				30D019B73A566313ABBBD354 /* Pods_AMTextFieldPickerExtensionTests.framework */,
+				D1BDC0C50B5BD4B94606F2D2 /* Pods_AMTextFieldPickerExtension.framework */,
+				CAF13567F3F2B77D3465DD1B /* Pods_AMTextFieldPickerExtensionTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -71,8 +77,8 @@
 				9243806E1B3B4A5900DBD4A8 /* AMTextFieldPickerExtension */,
 				9243807B1B3B4A5900DBD4A8 /* AMTextFieldPickerExtensionTests */,
 				9243806D1B3B4A5900DBD4A8 /* Products */,
-				A92D4EB82951C3A851F1FA1D /* Pods */,
-				679CE2193D499980177EA65D /* Frameworks */,
+				C189AF7401B930D7405B2E64 /* Pods */,
+				7081A8798E2E4FE7757C2B58 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -120,11 +126,13 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		A92D4EB82951C3A851F1FA1D /* Pods */ = {
+		C189AF7401B930D7405B2E64 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				64D527938E26F5D4731A14F7 /* Pods-AMTextFieldPickerExtensionTests.debug.xcconfig */,
-				E18BE1EEF891C05C1222A4FA /* Pods-AMTextFieldPickerExtensionTests.release.xcconfig */,
+				91E0D953CC9FCB5821FD1CA7 /* Pods-AMTextFieldPickerExtension.debug.xcconfig */,
+				FF2D965EFBC89B3F28CA0182 /* Pods-AMTextFieldPickerExtension.release.xcconfig */,
+				BDF0A5FB18F1E7F175678E7A /* Pods-AMTextFieldPickerExtensionTests.debug.xcconfig */,
+				87D7E3BC68669719C0AC3EED /* Pods-AMTextFieldPickerExtensionTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -147,10 +155,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 924380821B3B4A5900DBD4A8 /* Build configuration list for PBXNativeTarget "AMTextFieldPickerExtension" */;
 			buildPhases = (
+				717460777A75A470FD474786 /* 📦 Check Pods Manifest.lock */,
 				924380671B3B4A5900DBD4A8 /* Sources */,
 				924380681B3B4A5900DBD4A8 /* Frameworks */,
 				924380691B3B4A5900DBD4A8 /* Headers */,
 				9243806A1B3B4A5900DBD4A8 /* Resources */,
+				0D7039873144D63083971257 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -165,12 +175,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 924380851B3B4A5900DBD4A8 /* Build configuration list for PBXNativeTarget "AMTextFieldPickerExtensionTests" */;
 			buildPhases = (
-				313B7999E158545CE3F92B50 /* Check Pods Manifest.lock */,
+				71B056A08CC6B4894FE6A439 /* 📦 Check Pods Manifest.lock */,
 				924380731B3B4A5900DBD4A8 /* Sources */,
 				924380741B3B4A5900DBD4A8 /* Frameworks */,
 				924380751B3B4A5900DBD4A8 /* Resources */,
-				DC2825E78A0C201797A330A3 /* Embed Pods Frameworks */,
-				1C27F01F5FDCDCF75CFE9F74 /* Copy Pods Resources */,
+				5CFA8BF2F024D8479153C27C /* 📦 Embed Pods Frameworks */,
+				6F37EC14C2CC6EE1432F6911 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -237,14 +247,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1C27F01F5FDCDCF75CFE9F74 /* Copy Pods Resources */ = {
+		0D7039873144D63083971257 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AMTextFieldPickerExtension/Pods-AMTextFieldPickerExtension-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5CFA8BF2F024D8479153C27C /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6F37EC14C2CC6EE1432F6911 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -252,14 +292,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		313B7999E158545CE3F92B50 /* Check Pods Manifest.lock */ = {
+		717460777A75A470FD474786 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -267,19 +307,19 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		DC2825E78A0C201797A330A3 /* Embed Pods Frameworks */ = {
+		71B056A08CC6B4894FE6A439 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AMTextFieldPickerExtensionTests/Pods-AMTextFieldPickerExtensionTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -404,6 +444,7 @@
 		};
 		924380831B3B4A5900DBD4A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 91E0D953CC9FCB5821FD1CA7 /* Pods-AMTextFieldPickerExtension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -423,6 +464,7 @@
 		};
 		924380841B3B4A5900DBD4A8 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FF2D965EFBC89B3F28CA0182 /* Pods-AMTextFieldPickerExtension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -441,7 +483,7 @@
 		};
 		924380861B3B4A5900DBD4A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 64D527938E26F5D4731A14F7 /* Pods-AMTextFieldPickerExtensionTests.debug.xcconfig */;
+			baseConfigurationReference = BDF0A5FB18F1E7F175678E7A /* Pods-AMTextFieldPickerExtensionTests.debug.xcconfig */;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -456,7 +498,7 @@
 		};
 		924380871B3B4A5900DBD4A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E18BE1EEF891C05C1222A4FA /* Pods-AMTextFieldPickerExtensionTests.release.xcconfig */;
+			baseConfigurationReference = 87D7E3BC68669719C0AC3EED /* Pods-AMTextFieldPickerExtensionTests.release.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = AMTextFieldPickerExtensionTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/AMTextFieldPickerExtension/UITextField+AMSetPicker.swift
+++ b/AMTextFieldPickerExtension/UITextField+AMSetPicker.swift
@@ -47,7 +47,10 @@ public extension UITextField {
   private func pickerToolbar() -> UIToolbar {
     let toolbar = UIToolbar(frame: CGRectMake(0, 0, 320, 44))
     let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: nil, action: nil)
-    let doneButton = UIBarButtonItem(barButtonSystemItem: .Done, target: self, action: "didPressPickerDoneButton:")
+    let doneButton = UIBarButtonItem(barButtonSystemItem: .Done,
+                                     target: self,
+                                     action: #selector(UITextField.didPressPickerDoneButton(_:)))
+    
     toolbar.items = [flexibleSpace, doneButton]
     
     return toolbar

--- a/AMTextFieldPickerExtensionTests/AMTextFieldPickerExtensionTests.swift
+++ b/AMTextFieldPickerExtensionTests/AMTextFieldPickerExtensionTests.swift
@@ -51,7 +51,7 @@ class AMTextFieldPickerExtensionTests: XCTestCase {
     expect(toolbar?.frame.height).to(beGreaterThanOrEqualTo(44))
     expect(toolbar?.items?.count).to(equal(2))
     let doneButton = toolbar?.items?.last
-    expect(doneButton?.action).to(equal("didPressPickerDoneButton:"))
+    expect(doneButton?.action).to(equal(#selector(UITextField.didPressPickerDoneButton(_:))))
     expect(doneButton?.target as? UITextField).to(beIdenticalTo(self.sut))
   }
   
@@ -87,7 +87,7 @@ class AMTextFieldPickerExtensionTests: XCTestCase {
     expect(toolbar?.frame.height).to(beGreaterThanOrEqualTo(44))
     expect(toolbar?.items?.count).to(equal(2))
     let doneButton = toolbar?.items?.last
-    expect(doneButton?.action).to(equal("didPressPickerDoneButton:"))
+    expect(doneButton?.action).to(equal(#selector(UITextField.didPressPickerDoneButton(_:))))
     expect(doneButton?.target as? UITextField).to(beIdenticalTo(self.sut))
   }
   

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,12 @@
 PODS:
-  - Nimble (3.0.0)
+  - Nimble (4.0.1)
 
 DEPENDENCIES:
   - Nimble
 
 SPEC CHECKSUMS:
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
+  Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: dd948e18df4997350a3cfbf4bd7be8389ec34c22
+
+COCOAPODS: 1.0.0


### PR DESCRIPTION
Updated pods. Now using Nimble 4.0.
Updated selector syntax to use new `#selector` syntax. 
All tests are passing.
